### PR TITLE
feat!: add cdk-exec --all

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@ Lambdas and State Machines in AWS.
 
 ```
 $ cdk-exec integ-cdk-exec/Function --input '{"succeed":true}'
-✨  Executing integ-cdk-exec-Function76856677-k5ehIzbG2T6S
+⚡  Executing integ-cdk-exec/Function/Resource (integ-cdk-exec-Function76856677-k5ehIzbG2T6S)
+
+
+✨  Final status of integ-cdk-exec/Function/Resource
 
 Output:
 {
@@ -76,7 +79,10 @@ $ cdk synth --output cdk.out
 
 ```
 $ cdk-exec integ-cdk-exec/StateMachine --input '{"succeed":true}'
-✨  Executing arn:aws:states:REGION:000000000000:stateMachine:StateMachine2E01A3A5-8z4XHXAvT3qq
+⚡  Executing integ-cdk-exec/StateMachine/Resource (arn:aws:states:REGION:000000000000:stateMachine:StateMachine2E01A3A5-8z4XHXAvT3qq)
+
+
+✨  Final status of integ-cdk-exec/StateMachine/Resource
 
 Output:
 {
@@ -90,7 +96,10 @@ Output:
 
 ```
 $ cdk-exec integ-cdk-exec/Function --input '{"succeed":true}'
-✨  Executing integ-cdk-exec-Function76856677-k5ehIzbG2T6S
+⚡  Executing integ-cdk-exec/Function/Resource (integ-cdk-exec-Function76856677-k5ehIzbG2T6S)
+
+
+✨  Final status of integ-cdk-exec/Function/Resource (integ-cdk-exec-Function76856677-k5ehIzbG2T6S)
 
 Output:
 {
@@ -105,7 +114,10 @@ Output:
 
 ```
 $ cdk-exec --app path/to/cdkout integ-cdk-exec/Function --input '{"json":"here"}'
-✨  Executing integ-cdk-exec-Function76856677-k5ehIzbG2T6S
+⚡  Executing integ-cdk-exec/Function/Resource (integ-cdk-exec-Function76856677-k5ehIzbG2T6S)
+
+
+✨  Final status of integ-cdk-exec/Function/Resource
 
 Output:
 {
@@ -125,8 +137,7 @@ is also a convenient shortcut when your app has only one executable resource.
 For example, if you have only one function or state machine in a stack, you
 can type `cdk-exec my-stack` and your resource will be found. If your entire
 app has only one executable resource, you can run `cdk-exec` without arguments
-to run it. However, if you provide an ambiguous path, matching more than one
-supported resource, you will receive an error message.
+to run it.
 
 **Path metadata**
 

--- a/src/cli/cdk-exec.ts
+++ b/src/cli/cdk-exec.ts
@@ -4,6 +4,7 @@ import chalk from 'chalk';
 import * as yargs from 'yargs';
 import { AwsSdk } from '../aws-sdk';
 import { AmbiguousPathError, Executor } from '../executor';
+import { MetadataMatch } from '../find-matching-resources';
 
 async function main(): Promise<number> {
   const args: any = yargs
@@ -22,6 +23,11 @@ async function main(): Promise<number> {
         type: 'boolean',
         description: 'Execute all matching resources',
       })
+      .option('metadata', {
+        type: 'array',
+        alias: 'm',
+        description: 'Match resources with the given metadata key or key=value',
+      })
       .option('input', {
         type: 'string',
         description: 'Execute with custom JSON input',
@@ -35,6 +41,7 @@ async function main(): Promise<number> {
     constructPath: args.path,
     app: args.app,
     all: args.all,
+    metadata: args.metadata ? new MetadataMatch(args.metadata) : undefined,
     input: args.input,
   });
 }
@@ -56,6 +63,11 @@ export interface CdkExecOptions {
   readonly constructPath?: string;
 
   /**
+   * Match records with the given metadata
+   */
+  readonly metadata?: MetadataMatch;
+
+  /**
    * Execution input.
    */
   readonly input?: string;
@@ -68,6 +80,7 @@ export async function cdkExec(options: CdkExecOptions): Promise<number> {
     const executors = await Executor.find({
       assembly,
       constructPath: options.constructPath,
+      metadata: options.metadata,
       sdk: new AwsSdk(),
     });
 

--- a/src/executor.ts
+++ b/src/executor.ts
@@ -1,7 +1,7 @@
 import * as cxapi from 'aws-cdk-lib/cx-api';
 import * as AWS from 'aws-sdk';
 import { IAwsSdk, LazyListStackResources } from './aws-sdk';
-import { findMatchingResources, MatchingResource } from './find-matching-resources';
+import { findMatchingResources, MatchingResource, MetadataMatch } from './find-matching-resources';
 
 const STATE_MACHINE_TYPE = 'AWS::StepFunctions::StateMachine';
 const LAMBDA_TYPE = 'AWS::Lambda::Function';
@@ -74,6 +74,11 @@ export interface FindExecutorOptions {
    * Path to the resource containing the state machine to execute.
    */
   readonly constructPath?: string;
+
+  /**
+   * Metadata of the resources to match.
+   */
+  readonly metadata?: MetadataMatch;
 
   /**
    * AWS SDK
@@ -215,11 +220,12 @@ function getLambdaErrorMessage(output: any) {
  * Finds an executor.
  */
 async function findExecutors(options: FindExecutorOptions): Promise<Executor[]> {
-  const { assembly, constructPath, sdk } = options;
+  const { assembly, constructPath, sdk, metadata } = options;
 
   const matchingResources = findMatchingResources({
     assembly,
     constructPath,
+    metadata,
     types: [
       STATE_MACHINE_TYPE,
       LAMBDA_TYPE,

--- a/src/find-matching-resources.ts
+++ b/src/find-matching-resources.ts
@@ -53,7 +53,7 @@ export function findMatchingResources(options: FindMatchingResourceOptions): Mat
       const resourceConstructPath = resourceRecord.Metadata[cxapi.PATH_METADATA_KEY] as string;
       if (!constructPath || resourceConstructPath === constructPath || resourceConstructPath.startsWith(`${constructPath}/`)) {
         matches.push({
-          logicalId,
+          logicalResourceId: logicalId,
           type,
           constructPath: resourceConstructPath,
           stackName: stack.stackName,
@@ -74,7 +74,7 @@ export interface MatchingResource {
   /**
    * Logical ID of the resource.
    */
-  readonly logicalId: string;
+  readonly logicalResourceId: string;
 
   /**
    * The CloudFormation type.

--- a/src/find-matching-resources.ts
+++ b/src/find-matching-resources.ts
@@ -12,6 +12,11 @@ export interface FindMatchingResourceOptions {
   readonly constructPath?: string;
 
   /**
+   * Metadata to search for.
+   */
+  readonly metadata?: MetadataMatch;
+
+  /**
    * Match only the given resource types.
    */
   readonly types: string[];
@@ -25,6 +30,7 @@ export function findMatchingResources(options: FindMatchingResourceOptions): Mat
     constructPath,
     types,
     assembly,
+    metadata,
   } = options;
 
   const matches = Array<MatchingResource>();
@@ -41,7 +47,8 @@ export function findMatchingResources(options: FindMatchingResourceOptions): Mat
       }
 
       const resourceRecord = resource as Record<string, any>;
-      if (typeof resourceRecord.Metadata !== 'object') {
+      const resourceMetadata = resourceRecord.Metadata;
+      if (typeof resourceMetadata !== 'object') {
         continue;
       }
 
@@ -50,7 +57,11 @@ export function findMatchingResources(options: FindMatchingResourceOptions): Mat
         continue;
       }
 
-      const resourceConstructPath = resourceRecord.Metadata[cxapi.PATH_METADATA_KEY] as string;
+      if (metadata && !metadata.matches(resourceMetadata)) {
+        continue;
+      }
+
+      const resourceConstructPath = resourceMetadata[cxapi.PATH_METADATA_KEY] as string;
       if (!constructPath || resourceConstructPath === constructPath || resourceConstructPath.startsWith(`${constructPath}/`)) {
         matches.push({
           logicalResourceId: logicalId,
@@ -85,4 +96,33 @@ export interface MatchingResource {
    * The resource's construct path metadata.
    */
   readonly constructPath: string;
+}
+
+/**
+ * Match resource metadata with the given specification.
+ */
+export class MetadataMatch {
+  readonly spec: Record<string, string | undefined>;
+
+  constructor(spec: string[]) {
+    this.spec = Object.fromEntries(
+      spec.map(metadata => metadata.split('=', 2)),
+    );
+  }
+
+  matches(resourceMetadata: Record<string, string>) {
+    for (const entry of Object.entries(this.spec)) {
+      const [key, value] = entry;
+
+      if (resourceMetadata[key] === undefined) {
+        return false;
+      }
+
+      if (value !== undefined && resourceMetadata[key] !== value) {
+        return false;
+      }
+    }
+
+    return true;
+  }
 }

--- a/src/find-matching-resources.ts
+++ b/src/find-matching-resources.ts
@@ -61,12 +61,12 @@ export function findMatchingResources(options: FindMatchingResourceOptions): Mat
         continue;
       }
 
-      const resourceConstructPath = resourceMetadata[cxapi.PATH_METADATA_KEY] as string;
-      if (!constructPath || resourceConstructPath === constructPath || resourceConstructPath.startsWith(`${constructPath}/`)) {
+      const pathMetadata = resourceMetadata[cxapi.PATH_METADATA_KEY] as string;
+      if (!constructPath || pathMetadata === constructPath || pathMetadata.startsWith(`${constructPath}/`)) {
         matches.push({
           logicalResourceId: logicalId,
           type,
-          constructPath: resourceConstructPath,
+          constructPath: pathMetadata,
           stackName: stack.stackName,
         });
       }

--- a/test/executor.test.ts
+++ b/test/executor.test.ts
@@ -32,28 +32,28 @@ describe('Executor', () => {
 
     test('L1 state machine executor', async () => {
       // WHEN
-      const executor = await Executor.find({
+      const executors = await Executor.find({
         sdk,
         constructPath: 'Stack/Boom/Resource',
         assembly,
       });
 
       // THEN
-      expect(executor).toBeInstanceOf(StateMachineExecutor);
-      expect(executor!.physicalResourceId).toEqual('physical-boom');
+      expect(executors[0]).toBeInstanceOf(StateMachineExecutor);
+      expect(executors[0].physicalResourceId).toEqual('physical-boom');
     });
 
     test('L2 state machine executor', async () => {
       // WHEN
-      const executor = await Executor.find({
+      const executors = await Executor.find({
         sdk: sdk,
         constructPath: 'Stack/Boom/Resource',
         assembly,
       });
 
       // THEN
-      expect(executor).toBeInstanceOf(StateMachineExecutor);
-      expect(executor!.physicalResourceId).toEqual('physical-boom');
+      expect(executors[0]).toBeInstanceOf(StateMachineExecutor);
+      expect(executors[0].physicalResourceId).toEqual('physical-boom');
     });
   });
 
@@ -86,33 +86,33 @@ describe('Executor', () => {
 
     test('L1 lambda function executor', async () => {
       // WHEN
-      const executor = await Executor.find({
+      const executors = await Executor.find({
         sdk,
         constructPath: 'Stack/Boom/Resource',
         assembly,
       });
 
       // THEN
-      expect(executor).toBeInstanceOf(LambdaFunctionExecutor);
-      expect(executor!.physicalResourceId).toEqual('physical-boom');
+      expect(executors[0]).toBeInstanceOf(LambdaFunctionExecutor);
+      expect(executors[0].physicalResourceId).toEqual('physical-boom');
     });
 
     test('L2 lambda function executor', async () => {
       // WHEN
-      const executor = await Executor.find({
+      const executors = await Executor.find({
         sdk,
         constructPath: 'Stack/Boom/Resource',
         assembly,
       });
 
       // THEN
-      expect(executor).toBeInstanceOf(LambdaFunctionExecutor);
-      expect(executor!.physicalResourceId).toEqual('physical-boom');
+      expect(executors[0]).toBeInstanceOf(LambdaFunctionExecutor);
+      expect(executors[0].physicalResourceId).toEqual('physical-boom');
     });
   });
 
   describe('errors', () => {
-    test('undefined when path not found', async () => {
+    test('path not found', async () => {
       const assembly = testAssembly(app => {
         new Stack(app, 'Stack');
       });
@@ -126,28 +126,7 @@ describe('Executor', () => {
       });
 
       // THEN
-      expect(executor).toBeUndefined();
-    });
-
-    test('errors on ambiguous path', async () => {
-      const assembly = testAssembly(app => {
-        const stack = new TestStack(app, 'Stack');
-        new aws_stepfunctions.StateMachine(stack, 'Boom1', {
-          definition: new aws_stepfunctions.Succeed(stack, 'Succeed1'),
-        });
-        new aws_stepfunctions.StateMachine(stack, 'Boom2', {
-          definition: new aws_stepfunctions.Succeed(stack, 'Succeed2'),
-        });
-      });
-
-      // WHEN
-      await expect(async () => {
-        await Executor.find({
-          sdk: new MockAwsSdk(),
-          assembly,
-          constructPath: 'Stack',
-        });
-      }).rejects.toThrow(/multiple/i);
+      expect(executor).toEqual([]);
     });
   });
 });
@@ -177,6 +156,8 @@ describe('StateMachineExecutor', () => {
 
     // WHEN
     const executor = new StateMachineExecutor({
+      constructPath: 'some/path',
+      logicalResourceId: 'SomePath',
       physicalResourceId: 'state-machine-arn',
       stepFunctions,
     });
@@ -210,6 +191,8 @@ describe('StateMachineExecutor', () => {
 
     // WHEN
     const executor = new StateMachineExecutor({
+      constructPath: 'some/path',
+      logicalResourceId: 'SomePath',
       physicalResourceId: 'state-machine-arn',
       stepFunctions,
     });
@@ -226,6 +209,8 @@ describe('StateMachineExecutor', () => {
 
     const executor = new StateMachineExecutor({
       physicalResourceId: 'state-machine-arn',
+      constructPath: 'some/path',
+      logicalResourceId: 'SomePath',
       stepFunctions,
     });
 
@@ -252,6 +237,8 @@ describe('LambdaFunctionExecutor', () => {
     // WHEN
     const executor = new LambdaFunctionExecutor({
       lambda,
+      constructPath: 'some/path',
+      logicalResourceId: 'SomePath',
       physicalResourceId: 'some-function-name',
     });
 
@@ -285,6 +272,8 @@ describe('LambdaFunctionExecutor', () => {
     // WHEN
     const executor = new LambdaFunctionExecutor({
       lambda,
+      constructPath: 'some/path',
+      logicalResourceId: 'SomePath',
       physicalResourceId: 'some-function-name',
     });
 
@@ -299,6 +288,8 @@ describe('LambdaFunctionExecutor', () => {
     const lambda = sdk.lambda();
 
     const executor = new LambdaFunctionExecutor({
+      constructPath: 'some/path',
+      logicalResourceId: 'SomePath',
       physicalResourceId: 'state-machine-arn',
       lambda,
     });

--- a/test/find-matching-resources.test.ts
+++ b/test/find-matching-resources.test.ts
@@ -1,5 +1,6 @@
+import { CfnResource } from 'aws-cdk-lib';
 import * as aws_stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
-import { findMatchingResources } from '../src/find-matching-resources';
+import { findMatchingResources, MetadataMatch } from '../src/find-matching-resources';
 import { testAssembly, TestStack } from './util';
 
 describe('findMatchingResources', () => {
@@ -37,5 +38,67 @@ describe('findMatchingResources', () => {
         type: 'AWS::StepFunctions::StateMachine',
       },
     ]);
+  });
+
+  describe('metadata', () => {
+    const assembly = testAssembly(app => {
+      const stack = new TestStack(app, 'Stack');
+      const sfn1 = new aws_stepfunctions.StateMachine(stack, 'Boom1', {
+        definition: new aws_stepfunctions.Succeed(stack, 'Succeed1'),
+      });
+      const sfn1Resource = sfn1.node.defaultChild as CfnResource;
+      sfn1Resource.addMetadata('group', 'sfn1');
+      sfn1Resource.addMetadata('other', 'other');
+
+      const sfn2 = new aws_stepfunctions.StateMachine(stack, 'Boom2', {
+        definition: new aws_stepfunctions.Succeed(stack, 'Succeed2'),
+      });
+      const sfn2Resource = sfn2.node.defaultChild as CfnResource;
+      sfn2Resource.addMetadata('group', 'sfn2');
+
+      new aws_stepfunctions.StateMachine(stack, 'Boom3', {
+        definition: new aws_stepfunctions.Succeed(stack, 'Succeed3'),
+      });
+    });
+
+    test('bare key', () => {
+      // WHEN
+      const matchingResources = findMatchingResources({
+        assembly,
+        types: ['AWS::StepFunctions::StateMachine'],
+        metadata: new MetadataMatch(['group']),
+      });
+
+      // THEN
+      expect(matchingResources).toHaveLength(2);
+      expect(matchingResources[0].constructPath).toEqual('Stack/Boom1/Resource');
+      expect(matchingResources[1].constructPath).toEqual('Stack/Boom2/Resource');
+    });
+
+    test('key=value', () => {
+      // WHEN
+      const matchingResources = findMatchingResources({
+        assembly,
+        types: ['AWS::StepFunctions::StateMachine'],
+        metadata: new MetadataMatch(['group=sfn2']),
+      });
+
+      // THEN
+      expect(matchingResources).toHaveLength(1);
+      expect(matchingResources[0].constructPath).toEqual('Stack/Boom2/Resource');
+    });
+
+    test('multiple keys and values', () => {
+      // WHEN
+      const matchingResources = findMatchingResources({
+        assembly,
+        types: ['AWS::StepFunctions::StateMachine'],
+        metadata: new MetadataMatch(['group', 'other']),
+      });
+
+      // THEN
+      expect(matchingResources).toHaveLength(1);
+      expect(matchingResources[0].constructPath).toEqual('Stack/Boom1/Resource');
+    });
   });
 });

--- a/test/find-matching-resources.test.ts
+++ b/test/find-matching-resources.test.ts
@@ -40,7 +40,7 @@ describe('findMatchingResources', () => {
     ]);
   });
 
-  describe('metadata', () => {
+  describe('metadata match', () => {
     const assembly = testAssembly(app => {
       const stack = new TestStack(app, 'Stack');
       const sfn1 = new aws_stepfunctions.StateMachine(stack, 'Boom1', {

--- a/test/find-matching-resources.test.ts
+++ b/test/find-matching-resources.test.ts
@@ -26,13 +26,13 @@ describe('findMatchingResources', () => {
     expect(results).toEqual([
       {
         constructPath: 'Stack/Boom1/Resource',
-        logicalId: 'STACKXBOOM1XRESOURCE',
+        logicalResourceId: 'STACKXBOOM1XRESOURCE',
         stackName: 'Stack',
         type: 'AWS::StepFunctions::StateMachine',
       },
       {
         constructPath: 'Stack/Boom2/Resource',
-        logicalId: 'STACKXBOOM2XRESOURCE',
+        logicalResourceId: 'STACKXBOOM2XRESOURCE',
         stackName: 'Stack',
         type: 'AWS::StepFunctions::StateMachine',
       },

--- a/test/util.ts
+++ b/test/util.ts
@@ -7,13 +7,17 @@ import * as AWS from 'aws-sdk';
 import { Construct } from 'constructs';
 import { IAwsSdk } from '../src/aws-sdk';
 
-export function testAssembly(cb: (app: App) => void): cxapi.CloudAssembly {
+export function testAssembly(cb: (app: App) => void, pathMetadata?: boolean): cxapi.CloudAssembly {
   const appDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tmp'));
+
+  const patchMetadataContext = (pathMetadata ?? true) ? {
+    [cxapi.PATH_METADATA_ENABLE_CONTEXT]: true,
+  } : undefined;
 
   const app = new App({
     outdir: appDir,
     context: {
-      [cxapi.PATH_METADATA_ENABLE_CONTEXT]: true,
+      ...patchMetadataContext,
     },
   });
 


### PR DESCRIPTION
Adds `cdk-exec --all` which executes all matching resources. Also introduces `--metadata` which matches resources with the given `CfnResource` metadata keys/values.